### PR TITLE
Appease shellcheck and show docker pull & bundler output

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -27,10 +27,22 @@ if [[ -z ${result} ]]; then
     export PATH=${CURRENT_PATH}:$PATH
     say "$(ok "Setup path: ${CURRENT_PATH}")"
 
+    say "Fetching Ruby gems"
+    pushd "${CURRENT_PATH}/.."
+    bundle
+    if [ $? -ne 0 ]; then
+        say "$(error "Failed to download Ruby gems")"
+        return
+    else
+        say "$(ok "Ruby gems installed")"
+    fi
+    popd
+
     say "Fetching course container from dockerhub"
     docker pull ${COURSE_IMAGE}
     if [ $? -ne 0 ]; then
         say "$(error "Failed to download course image")"
+        return
     else
         say "$(ok "Downloaded course image")"
     fi


### PR DESCRIPTION
* Minor tweaks to the bash scripts to keep my linter happy.
* Changed the `docker pull` step to show it's output on the console whilst it is running. This prevents the urge to press CTRL-C and retry the script when working on slow network connections.
* Added a `bundle` step as part of the setup script.
* Exit (using `return`) from setup script on error so that the last line printed on the console will be the error rather than an OK message from subsequent steps. 
