### PR TITLE
Add code coverage check in to default rake task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.retry
 *.log
 .vagrant/
+coverage/

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,10 @@
+SimpleCov.add_group 'Commands', 'commands'
+SimpleCov.add_group 'utils', 'utils'
+
+
+SimpleCov.profiles.define 'rspec' do
+  add_filter "/spec/"
+end
+
+SimpleCov.profiles.define 'exercise_generation' do
+end

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,11 @@ source 'https://rubygems.org'
 
 gem 'colorize'
 gem 'json'
-gem 'rubocop'
 gem 'thor'
+
+group :development do
+  gem 'rake'
+  gem 'rspec', require: 'rspec/core/rake_task'
+  gem 'rubocop'
+  gem 'simplecov', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
     declarative-option (0.1.0)
     diff-lcs (1.3)
     digest-crc (0.4.1)
+    docile (1.3.1)
     docker-api (1.34.2)
       excon (>= 0.47.0)
       multi_json
@@ -244,6 +245,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.0.2)
     rainbow (3.0.0)
+    rake (12.3.1)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -282,6 +284,11 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     sslshake (1.2.0)
     stackdriver-core (1.3.0)
       google-cloud-core (~> 1.2)
@@ -330,7 +337,10 @@ DEPENDENCIES
   colorize
   inspec
   json
+  rake
+  rspec
   rubocop
+  simplecov
   thor
 
 BUNDLED WITH

--- a/ci_training.iml
+++ b/ci_training.iml
@@ -21,6 +21,7 @@
     <orderEntry type="library" scope="PROVIDED" name="declarative-option (v0.1.0, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="diff-lcs (v1.3, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="digest-crc (v0.4.1, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="docile (v1.3.1, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="docker-api (v1.34.2, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="domain_name (v0.5.20180417, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="erubis (v2.7.0, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
@@ -96,6 +97,7 @@
     <orderEntry type="library" scope="PROVIDED" name="pry (v0.11.3, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="public_suffix (v3.0.2, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rainbow (v3.0.0, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rake (v12.3.1, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="representable (v3.0.4, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="retriable (v3.1.1, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rly (v0.2.3, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
@@ -111,6 +113,8 @@
     <orderEntry type="library" scope="PROVIDED" name="rubyzip (v1.2.1, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="semverse (v2.0.0, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="signet (v0.8.1, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simplecov (v0.16.1, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simplecov-html (v0.10.2, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="sslshake (v1.2.0, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="stackdriver-core (v1.3.0, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="thor (v0.20.0, RVM: ruby-2.4.3 [ci-cd-training]) [gem]" level="application" />

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,6 @@
 $LOAD_PATH.unshift("#{__dir__}/../bin/support/ruby/lib")
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start('rspec')
+end
+require 'commands'

--- a/tasks/exercises.rake
+++ b/tasks/exercises.rake
@@ -1,0 +1,18 @@
+desc 'generate project exercises from .templates/*.erb templates'
+task :generate_exercises, :mode do |_task, args|
+  quiet = args[:mode] != 'verbose'
+
+  require 'simplecov'
+  SimpleCov.start('exercise_generation')
+
+  require 'commands'
+  begin
+    current_dir = Dir.pwd
+    Dir["#{__dir__}/../exercises/**/.templates"].each do |templates_dir|
+      Dir.chdir("#{templates_dir}/..")
+      Exercise::Command.new([], { quiet: quiet }, {}).generate
+    end
+  ensure
+    Dir.chdir(current_dir)
+  end
+end

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -1,0 +1,15 @@
+require_relative 'support/lint'
+
+desc 'lint project shellscripts'
+task :shellcheck do
+  Lint.run_linter(:shellcheck)
+end
+
+desc 'lint project ruby source code'
+task :rubocop do
+  Lint.run_linter(:rubocop)
+end
+
+task :coverage_check do
+  SimpleCov.minimum_coverage 90
+end

--- a/tasks/support/lint.rb
+++ b/tasks/support/lint.rb
@@ -1,0 +1,10 @@
+$LOAD_PATH.unshift("#{__dir__}/../../bin/support/ruby/lib")
+require 'utils/commandline'
+module Lint
+  extend Commandline
+  def self.run_linter(linter)
+    result = run "codeclimate analyze -e #{linter} ."
+    puts result.stdout
+    raise unless result.stdout.include? 'Found 0 issues'
+  end
+end


### PR DESCRIPTION
Coverage code coverage requirements is set to 90% we are currently at 92%

This figure tells how much of the code is currently used, not necessarily that we have tests covering this much of the code. 

Specs currently hit around 66% of the code, the rest of the coverage comes from tracking what is used when the exercises are played through. 

In any case this figure isn't to bad at all and as we move on from the prototyping this number should and test coverage should continue to improve.

coverage report is can be viewed by opening `coverage/index.html` in a browser

This pull request relates #27