### PR TITLE
improved .netrc insrtructions

### DIFF
--- a/.templates/README.md.erb
+++ b/.templates/README.md.erb
@@ -38,10 +38,12 @@ For this material you will need the following:
       login <username>
       password <password>
   ```
-2. Fork this repo
-3. Clone your fork: `git clone https://github.com/<youruser>/<fork>.git cic`
-4. cd in to your checkout: `cd cic`
-5. setup the courseware: `./bin/setup`
+  **Note:** If you are using MacOSX you might find that `~/.netrc` is a directory on your machine. In this case replace the directory for a file as described above.
+2. Set restrictive permissions on `~/.netrc` e.g. by running: `chmod 0600 ~/.netrc`
+3. Fork this repo
+4. Clone your fork: `git clone https://github.com/<youruser>/<fork>.git cic`
+5. cd in to your checkout: `cd cic`
+6. setup the courseware: `./bin/setup`
 
 ### Starting a learning track
 To see the Learning tracks that CIC contains run: `<%= command('cic track list') %>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ To render a template in the `.templates` directory, navigate to the root of your
 # Generating template: .templates/README.md.erb #
 #################################################
 Rendering: .templates/README.md.erb
-[OK] Finished: /vols/ansible_25682/exercise_name/.templates/README.md.erb
+[OK] Finished: /vols/ansible_25748/exercise_name/.templates/README.md.erb
 
 ```
 
@@ -123,4 +123,4 @@ There will be times where you want to wait for something to happen before the `c
 
   
 
-Revision: cec7eba240340f7100f39267d124fbd5
+Revision: a5bc3e6c95b4288661f22ce74dce2bce

--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ For this material you will need the following:
       login <username>
       password <password>
   ```
-2. Fork this repo
-3. Clone your fork: `git clone https://github.com/<youruser>/<fork>.git cic`
-4. cd in to your checkout: `cd cic`
-5. setup the courseware: `./bin/setup`
+  **Note:** If you are using MacOSX you might find that `~/.netrc` is a directory on your machine. In this case replace the directory for a file as described above.
+2. Set restrictive permissions on `~/.netrc` e.g. by running: `chmod 0600 ~/.netrc`
+3. Fork this repo
+4. Clone your fork: `git clone https://github.com/<youruser>/<fork>.git cic`
+5. cd in to your checkout: `cd cic`
+6. setup the courseware: `./bin/setup`
 
 ### Starting a learning track
 To see the Learning tracks that CIC contains run: `cic track list`
@@ -75,4 +77,4 @@ Many hands make light work and your help is needed! View the [Contributing Guide
 
   
 
-Revision: 1b053c6df6cb8cd34407d63afc789dca
+Revision: a3cddb2efa29975ce2c84ba98bae2bda

--- a/doc/Exercise.html
+++ b/doc/Exercise.html
@@ -105,7 +105,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Nov 14 15:48:33 2018 by
+  Generated on Wed Nov 14 16:01:40 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.16 (ruby-2.4.3).
 </div>

--- a/doc/Exercise/Instructions.html
+++ b/doc/Exercise/Instructions.html
@@ -1421,7 +1421,7 @@ Change directory so that subsequent commands are executed in the correct context
 </div>
 
       <div id="footer">
-  Generated on Wed Nov 14 15:48:33 2018 by
+  Generated on Wed Nov 14 16:01:40 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.16 (ruby-2.4.3).
 </div>

--- a/doc/Exercise/Instructions/EnvironmentVariableMissingError.html
+++ b/doc/Exercise/Instructions/EnvironmentVariableMissingError.html
@@ -204,7 +204,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Nov 14 15:48:33 2018 by
+  Generated on Wed Nov 14 16:01:40 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.16 (ruby-2.4.3).
 </div>

--- a/doc/Exercise/Instructions/TimeoutError.html
+++ b/doc/Exercise/Instructions/TimeoutError.html
@@ -124,7 +124,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Nov 14 15:48:33 2018 by
+  Generated on Wed Nov 14 16:01:40 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.16 (ruby-2.4.3).
 </div>

--- a/doc/_index.html
+++ b/doc/_index.html
@@ -134,7 +134,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Nov 14 15:48:33 2018 by
+  Generated on Wed Nov 14 16:01:40 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.16 (ruby-2.4.3).
 </div>

--- a/doc/file.README.html
+++ b/doc/file.README.html
@@ -112,7 +112,9 @@ Your entry should look something like this:
 machine api.github.com
   login &lt;username&gt;
   password &lt;password&gt;
-</code></li>
+</code>
+<strong>Note:</strong> If you are using MacOSX you might find that <code>~/.netrc</code> is a directory on your machine. In this case replace the directory for a file as described above</li>
+<li>Set restrictive permissions on <code>~/.netrc</code> e.g. by running: <code>chmod 0600 ~/.netrc</code></li>
 <li>Fork this repo</li>
 <li>Clone your fork: <code>git clone https://github.com/&lt;youruser&gt;/&lt;fork&gt;.git cic</code></li>
 <li>cd in to your checkout: <code>cd cic</code></li>
@@ -152,11 +154,11 @@ E.g. <code>cic track start ansible --fork youruser/fork-name</code></p>
 <li>want to work on the CIC framework itself</li>
 </ul>
 
-<p>Revision: 2f6f09f2edc9c684c43a6527edf8f8b0</p>
+<p>Revision: a35aa7321881ac618e1f2ff4ef72887d</p>
 </div></div>
 
       <div id="footer">
-  Generated on Wed Nov 14 15:48:33 2018 by
+  Generated on Wed Nov 14 16:01:40 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.16 (ruby-2.4.3).
 </div>

--- a/doc/index.html
+++ b/doc/index.html
@@ -112,7 +112,9 @@ Your entry should look something like this:
 machine api.github.com
   login &lt;username&gt;
   password &lt;password&gt;
-</code></li>
+</code>
+<strong>Note:</strong> If you are using MacOSX you might find that <code>~/.netrc</code> is a directory on your machine. In this case replace the directory for a file as described above</li>
+<li>Set restrictive permissions on <code>~/.netrc</code> e.g. by running: <code>chmod 0600 ~/.netrc</code></li>
 <li>Fork this repo</li>
 <li>Clone your fork: <code>git clone https://github.com/&lt;youruser&gt;/&lt;fork&gt;.git cic</code></li>
 <li>cd in to your checkout: <code>cd cic</code></li>
@@ -152,11 +154,11 @@ E.g. <code>cic track start ansible --fork youruser/fork-name</code></p>
 <li>want to work on the CIC framework itself</li>
 </ul>
 
-<p>Revision: 2f6f09f2edc9c684c43a6527edf8f8b0</p>
+<p>Revision: a35aa7321881ac618e1f2ff4ef72887d</p>
 </div></div>
 
       <div id="footer">
-  Generated on Wed Nov 14 15:48:33 2018 by
+  Generated on Wed Nov 14 16:01:40 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.16 (ruby-2.4.3).
 </div>

--- a/doc/top-level-namespace.html
+++ b/doc/top-level-namespace.html
@@ -100,7 +100,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Nov 14 15:48:33 2018 by
+  Generated on Wed Nov 14 16:01:40 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.16 (ruby-2.4.3).
 </div>


### PR DESCRIPTION
@heathtechnical found that the instructions did not include an instruction telling reader to set the correct permissions on the .netrc file. Not doing so stops the `cic track start` command from working properly.